### PR TITLE
Make compile using MingW (gcc 4.6.0) using 64 bit Windows 7, where SSIZE...

### DIFF
--- a/tifffile.c
+++ b/tifffile.c
@@ -103,6 +103,13 @@ typedef _W64 unsigned int  uintptr_t;
 /* non MS compilers */
 #include <stdint.h>
 #include <limits.h>
+#ifndef SSIZE_MAX
+#ifdef _WIN64
+#define SSIZE_MAX (9223372036854775808L)
+#else
+#define SSIZE_MAX (2147483648)
+#endif
+#endif
 #endif
 
 #define SWAP2BYTES(x) \


### PR DESCRIPTION
SSIZE._MAX is not properly defined in limits.h 
