### PR TITLE
FIX: Fix _replace_by kwarg, remove whitespace, iterate minor version.

### DIFF
--- a/tifffile.py
+++ b/tifffile.py
@@ -149,7 +149,7 @@ from xml.etree import cElementTree as etree
 
 import numpy
 
-from . import _tifffile
+import _tifffile
 
 __version__ = '0.4.1'
 __docformat__ = 'restructuredtext en'

--- a/tifffile.py
+++ b/tifffile.py
@@ -1,5 +1,3 @@
-
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # tifffile.py
@@ -151,9 +149,9 @@ from xml.etree import cElementTree as etree
 
 import numpy
 
-import _tifffile
+from . import _tifffile
 
-__version__ = '0.4'
+__version__ = '0.4.1'
 __docformat__ = 'restructuredtext en'
 __all__ = ('imsave', 'imread', 'imshow', 'TiffFile', 'TiffWriter',
            'TiffSequence')
@@ -3114,7 +3112,7 @@ def _replace_by(module_function, package=None, warn=False):
                 full_name = modname
             else:
                 full_name = package + '.' + modname
-            module = __import__(full_name, romlist=[modname])
+            module = __import__(full_name, fromlist=[modname])
             func, oldfunc = getattr(module, function), func
             globals()['__old_' + func.__name__] = oldfunc
         except Exception:
@@ -4858,4 +4856,3 @@ if sys.version_info[0] > 2:
 
 if __name__ == "__main__":
     sys.exit(main())
-


### PR DESCRIPTION
Resolves the `_replace_by` problem and minor whitespace cleanup at top & bottom of file.

Now version 0.4.1, minor point release for bugfix.