### PR TITLE
OME Series: In 'modulo' tags, allow non-integer Start/End/Step attributes

### DIFF
--- a/tifffile/tifffile.py
+++ b/tifffile/tifffile.py
@@ -1668,10 +1668,10 @@ class TiffFile(object):
                                 newaxis = along.attrib.get('Type', 'other')
                                 newaxis = AXES_LABELS[newaxis]
                                 if 'Start' in along.attrib:
-                                    labels = range(
-                                        int(along.attrib['Start']),
-                                        int(along.attrib['End']) + 1,
-                                        int(along.attrib.get('Step', 1)))
+                                    step = float(along.attrib.get('Step', 1))
+                                    start = float(along.attrib['Start'])
+                                    stop = float(along.attrib['End']) + step
+                                    labels = numpy.arange(start, stop, step)
                                 else:
                                     labels = [label.text for label in along
                                               if label.tag.endswith('Label')]


### PR DESCRIPTION
Here's a snippet of metadata from an OME-TIFF file that was created by the BioFormats `bfconvert` tool:

``` xml
<XMLAnnotation ID="Annotation:11" Namespace="openmicroscopy.org/omero/dimension/modulo">
   <Value>
      <Modulo namespace="http://www.openmicroscopy.org/Schemas/Additions/2011-09">
         <ModuloAlongC End="1.0" Start="0.0" Step="1.0" Type="other" TypeDescription="TCSPC" />
      </Modulo>
   </Value>
</XMLAnnotation>
```

Unfortunately, `tifffile.py` chokes[1] on the attribute `Start="0.0"`, because it expects an `int`, not a `float`.  I asked about this on the ome-devel mailing list[2], and I was told that this metadata from `bfconvert` is correct.  Therefore, here's a little PR to `tifffile.py`, to allow `float` in that attribute.

[1]: For the record, the error from `tifffile.py` is the following:

``` pytb
  File "/Users/bergs/Documents/workspace/ilastik-meta/lazyflow/lazyflow/operators/ioOperators/opTiffReader.py", line 47, in setupOutputs
    series = tiff_file.series[0]
  File "/miniconda2/envs/ilastik-new/lib/python2.7/site-packages/tifffile/tifffile.py", line 1177, in __get__
    value = self.func(instance)
  File "/miniconda2/envs/ilastik-new/lib/python2.7/site-packages/tifffile/tifffile.py", line 1494, in series
    series = self._ome_series()
  File "/miniconda2/envs/ilastik-new/lib/python2.7/site-packages/tifffile/tifffile.py", line 1672, in _ome_series
    int(along.attrib['Start']),
ValueError: invalid literal for int() with base 10: '0.0'
```

[2]: http://lists.openmicroscopy.org.uk/pipermail/ome-devel/2016-July/003723.html
